### PR TITLE
Do not update folder hashes

### DIFF
--- a/src/Resources/contao/classes/pdfNcAttachmentHooks.php
+++ b/src/Resources/contao/classes/pdfNcAttachmentHooks.php
@@ -157,7 +157,6 @@ class pdfNcAttachmentHooks extends \Contao\Backend
 
             //--- Enter PDF file in the file manager ---
             $objFile = \Contao\Dbafs::addResource( $pdfdatei );
-            \Contao\Dbafs::updateFolderHashes(  $savepath );
 
             //--- Entry in log ---
             \Contao\System::Log('PDF attachment "' . $filename . '.pdf" has been created', __METHOD__, TL_ACCESS);


### PR DESCRIPTION
`Dbafs::addResource` already updates the folder hashes, so there is no need to do it again.